### PR TITLE
Update error messages in LimitToRange method

### DIFF
--- a/BidCalculator.Base/Extensions/DecimalExtensions.cs
+++ b/BidCalculator.Base/Extensions/DecimalExtensions.cs
@@ -9,8 +9,8 @@
 
         public static decimal LimitToRange(this decimal value, decimal minimum, decimal maximum)
         {
-            if (minimum > maximum) throw new ArgumentException("Minimum is above maximum", "minimum");
-            if (maximum < minimum) throw new ArgumentException("Maximum is below minimum ", "maximum");
+            if (minimum > maximum) throw new ArgumentException("Minimum is above maximum", nameof(minimum));
+            if (maximum < minimum) throw new ArgumentException("Maximum is below minimum ", nameof(maximum));
 
             return Math.Min(maximum, Math.Max(minimum, value));
         }


### PR DESCRIPTION
Refactored the `LimitToRange` method in the `DecimalExtensions` class to use the `nameof` operator for parameter names in error messages, enhancing maintainability.